### PR TITLE
Fix agent ping and clean up WhatsApp service

### DIFF
--- a/rh_kelly_agent/agent.py
+++ b/rh_kelly_agent/agent.py
@@ -215,4 +215,8 @@ root_agent.instruction = ("Voce e a Kelly, especialista em recrutamento da nossa
 # Configura o backend de memória para usar Redis. A URI é lida da variável REDIS_URL.
 redis_url = os.environ.get("REDIS_URL")
 if redis_url and RedisMemory is not None:
-    root_agent.memory_backend = RedisMemory(url=redis_url)
+    try:
+        root_agent.memory_backend = RedisMemory(url=redis_url)
+    except Exception as _mem_exc:
+        # Falha ao inicializar o backend de memória; segue sem persistência externa
+        print(f"RedisMemory init error: {_mem_exc}")


### PR DESCRIPTION
## Summary
- Complete the `/agent-ping` endpoint so it returns the agent's final response text and handles errors gracefully
- Simplify the WhatsApp service by trimming corrupted Flow Data code and keeping a minimal `/flow-data` endpoint
- Guard Redis memory backend initialization so the service still starts if Redis is unavailable

## Testing
- `python -m py_compile services/whatsapp.py rh_kelly_agent/agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b59c34d6bc832d9e290530fc6a614a