### PR TITLE
feat(leads): save decline flow with city

### DIFF
--- a/services/whatsapp.py
+++ b/services/whatsapp.py
@@ -68,7 +68,8 @@ def _load_intro_script() -> Dict[str, Any]:
         try:
             base = os.path.dirname(os.path.dirname(__file__))
             path = os.path.join(base, "rh_kelly_agent", "data", "roteiro_intro.json")
-            with open(path, "r", encoding="utf-8") as f:
+            # Tolerate UTF-8 BOM (files saved on Windows PowerShell)
+            with open(path, "r", encoding="utf-8-sig") as f:
                 _INTRO_SCRIPT = json.load(f)
         except Exception as exc:
             print(f"load intro script error: {exc}")

--- a/services/whatsapp.py
+++ b/services/whatsapp.py
@@ -799,7 +799,7 @@ def _save_lead_record(user_id: str) -> None:
                     "DATA_ISO": iso,
                     "NOME": row.get("nome"),
                     "TELEFONE": row.get("user_id"),
-                    "PERFIL_APROVADO": "Sim" if aprovado else "N�o",
+                    "PERFIL_APROVADO": "Sim" if aprovado else "N�o",
                     "PERFIL_NOTA": score,
                     "PROTOCOLO": protocolo,
                     "TURNO_ESCOLHIDO": turno,
@@ -1046,6 +1046,7 @@ async def handle_webhook(request: Request):
             if t in {"ajuda", "help"}: return "ajuda"
             if t in {"humano", "atendente", "suporte"}: return "humano"
             if t in {"status", "progresso"}: return "status"
+            if t in {"comandos", "comando", "help comandos"}: return "comandos"
             return ""
 
         cmd = _cmd(texto_usuario)
@@ -1110,8 +1111,21 @@ async def handle_webhook(request: Request):
                 "req_android": "Responda tocando em Sim ou Não.",
                 "offer_positions": "Toque em uma vaga do menu para selecionar.",
             }
-            send_text_message(from_number, f"Ajuda: {tips.get(st, 'Selecione uma opção do menu abaixo.')} ")
+            send_text_message(from_number, "Ajuda: " + (tips.get(st, "Selecione uma opcao do menu abaixo.")) + "\nDigite 'comandos' para ver a lista completa de comandos.")
             _resend_last_menu(from_number, ctx)
+        if cmd == "comandos":
+            guide = (
+                "Guia rapido de comandos:\n"
+                "- menu: reenvia o ultimo menu\n"
+                "- voltar: volta uma etapa\n"
+                "- recomecar: inicia do zero\n"
+                "- status: mostra etapa, cidade, requisitos e progresso\n"
+                "- ajuda: dica da etapa atual\n"
+                "- humano: encaminhar para atendimento humano\n\n"
+                "Dica: responda tocando nas opcoes quando possivel."
+            )
+            send_text_message(from_number, guide)
+            if ctx.get("last_menu"): _resend_last_menu(from_number, ctx)
             return {"status": "handled"}
         if cmd == "status":
             st_map = {
@@ -1498,6 +1512,8 @@ if __name__ == "__main__":
     import uvicorn
     port = int(os.environ.get("PORT", 8080))
     uvicorn.run(app, host="0.0.0.0", port=port)
+
+
 
 
 


### PR DESCRIPTION
Quando o candidato responde **Não** na última mensagem de introdução:\n\n- Pergunta a cidade de atuação (menu de cidades)\n- Salva o registro na planilha (campos: DATA_ISO, NOME, TELEFONE, PERFIL_APROVADO=Não, PROTOCOLO, CIDADE)\n- Finaliza atendimento\n\nExtras:\n- Seleção de cidade agora considera o estágio (await_city vs await_city_reject)\n- PERFIL_APROVADO mapeado para 'Não' corretamente\n- Loader do roteiro lê UTF-8 com BOM (utf-8-sig)\n\nApós merge, favor redeployar o serviço.