### PR TITLE
feat(intro): add 'Ajuda' button alongside 'Avancar'

### DIFF
--- a/services/whatsapp.py
+++ b/services/whatsapp.py
@@ -575,7 +575,9 @@ def _handle_city_selection_reject(destino: str, user_id: str, selected: str) -> 
     _save_lead_record(user_id)
     ctx["stage"] = "final"
     _save_ctx(user_id, ctx)
-    return {"handled": True}def _send_city_menu(destino: str, user_id: str, ctx: Optional[Dict[str, Any]] = None, prompt: Optional[str] = None) -> None:
+    return {"handled": True}
+
+def _send_city_menu(destino: str, user_id: str, ctx: Optional[Dict[str, Any]] = None, prompt: Optional[str] = None) -> None:
     if ctx is None:
         ctx = _load_ctx(user_id) or {}
 
@@ -1512,6 +1514,8 @@ if __name__ == "__main__":
     import uvicorn
     port = int(os.environ.get("PORT", 8080))
     uvicorn.run(app, host="0.0.0.0", port=port)
+
+
 
 
 

--- a/services/whatsapp.py
+++ b/services/whatsapp.py
@@ -95,7 +95,7 @@ def send_intro_message(destino: str, user_id: str, idx: int, nome: str) -> None:
     if idx == len(intro_messages):
         buttons = [("Sim", "Sim"), ("Não", "Não")]
     else:
-        buttons = [("intro_next", next_label)]
+        buttons = [("intro_next", next_label), ("ajuda", "Ajuda")]
 
     # Envia o texto longo e, em seguida, um corpo compacto com botões,
     # evitando que 'ajuda/menu' reenviem o texto longo da introducao.


### PR DESCRIPTION
- Em send_intro_message, quando houver avancar, adiciona-se tambem o botao 'Ajuda' (id: ajuda).\n- py_compile OK.\n- Deduplicacao de webhook ja presente no handler (/webhook) com Redis/in-memory e TTL (_SEEN_TTL_SEC).